### PR TITLE
Add linear probe on the STL-10 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ echo "DATADIR=/path/to/data" > .env
 
 ### MAE training
 
-Training options are provided through configuration files, handled by [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_cli.html). See `configs/` for examples.
+Training options are provided through configuration files, handled by [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_cli.html). See `config/` for examples.
 
 Train an MAE model on the CUB dataset:
 ```bash
-python train.py fit -c configs/mae.yaml -c configs/data/cub_mae.yaml
+python train.py fit -c config/mae.yaml -c config/data/cub_mae.yaml
 ```
 
 Using multiple GPUs:
 ```bash
-python train.py fit -c configs/mae.yaml -c configs/data/cub_mae.yaml --trainer.devices 8
+python train.py fit -c config/mae.yaml -c config/data/cub_mae.yaml --trainer.devices 8
 ```
 
 ### Fine-tuning
@@ -73,7 +73,7 @@ The default model uses ViT-Base for the encoder, and a small ViT (`depth=6`, `wi
 
 Image reconstructions of CUB validation set images after training with the following command:
 ```bash
-python train.py fit -c configs/mae.yaml -c configs/data/cub_mae.yaml --data.init_args.batch_size 256 --data.init_args.num_workers 12
+python train.py fit -c config/mae.yaml -c config/data/cub_mae.yaml --data.init_args.batch_size 256 --data.init_args.num_workers 12
 ```
 
 ![Bird Reconstructions](samples/bird-samples.png)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Now, append a linear probe to the last layer of the frozen encoder and discard t
 python linear_probe.py -c config/linear_probe.yaml -c config/data/stl10_linear_probe.yaml --model.init_args.ckpt_path <path to pretrained .ckpt>
 ``` 
 
+
 ### Fine-tuning
 
 Not yet implemented.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Now, append a linear probe to the last layer of the frozen encoder and discard t
 python linear_probe.py -c config/linear_probe.yaml -c config/data/stl10_linear_probe.yaml --model.init_args.ckpt_path <path to pretrained .ckpt>
 ``` 
 
+This yields 77.96\% accuracy on the test data.
+
 
 ### Fine-tuning
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A simple, unofficial implementation of MAE ([Masked Autoencoders are Scalable Vision Learners](https://arxiv.org/abs/2111.06377)) using  [pytorch-lightning](https://www.pytorchlightning.ai/). A PyTorch implementation by the authors can be found [here](https://github.com/facebookresearch/mae).
 
-Currently implements training on [CUB](http://www.vision.caltech.edu/visipedia/CUB-200-2011.html) and [StanfordCars](http://ai.stanford.edu/~jkrause/cars/car_dataset.html), but is easily extensible to any other image dataset.
+Currently implements training on [CUB](http://www.vision.caltech.edu/visipedia/CUB-200-2011.html), [StanfordCars](http://ai.stanford.edu/~jkrause/cars/car_dataset.html), [STL-10](https://cs.stanford.edu/~acoates/stl10/) but is easily extensible to any other image dataset.
 
 ## Updates
 
@@ -53,6 +53,16 @@ Using multiple GPUs:
 ```bash
 python train.py fit -c config/mae.yaml -c config/data/cub_mae.yaml --trainer.devices 8
 ```
+### Linear probing (currently only supported on STL-10)
+Evaluate the learned representations using a linear probe. First, pretrain the model on the 100.000 samples of the 'unlabeled' split.
+```bash
+python train.py fit -c config/mae.yaml -c config/data/stl10_mae.yaml
+```
+Now, append a linear probe to the last layer of the frozen encoder and discard the decoder. The appended classifier is then trained on 4000 labeled samples of the 'train' split (another 1000 are used for training validation) and evaluated on the 'test' split. To do so, simply provide the path to the pretrained model checkpoint in the command below.
+
+```bash
+python linear_probe.py -c config/linear_probe.yaml -c config/data/stl10_linear_probe.yaml --model.init_args.ckpt_path <path to pretrained .ckpt>
+``` 
 
 ### Fine-tuning
 

--- a/config/data/stl10_linear_probe.yaml
+++ b/config/data/stl10_linear_probe.yaml
@@ -1,5 +1,5 @@
 data:
-  class_path: datamodule.STL10PretrainDataModule
+  class_path: datamodule.STL10LinearProbeDataModule
   init_args:
     data_dir: ${oc.env:DATADIR}/STL10
     batch_size: 64

--- a/config/data/stl10_mae.yaml
+++ b/config/data/stl10_mae.yaml
@@ -1,7 +1,7 @@
 data:
   class_path: datamodule.STL10DataModule
   init_args:
-    data_dir: ${oc.env:DATADIR}/stl10_binary/
+    data_dir: ${oc.env:DATADIR}
     batch_size: 8
     num_workers: 0
     num_samples: 100000

--- a/config/data/stl10_mae.yaml
+++ b/config/data/stl10_mae.yaml
@@ -1,0 +1,7 @@
+data:
+  class_path: datamodule.STL10DataModule
+  init_args:
+    data_dir: ${oc.env:DATADIR}/stl10_binary/
+    batch_size: 8
+    num_workers: 0
+    num_samples: 100000

--- a/config/linear_probe.yaml
+++ b/config/linear_probe.yaml
@@ -1,0 +1,23 @@
+seed_everything: 123
+
+trainer:
+  devices: 1
+  strategy: auto
+  max_epochs: 100
+  precision: 16-mixed
+  callbacks:
+    - class_path: pytorch_lightning.callbacks.ModelCheckpoint
+      init_args:
+        filename: latest
+        every_n_epochs: 1
+        save_on_train_epoch_end: True
+    - class_path: pytorch_lightning.callbacks.lr_monitor.LearningRateMonitor
+      init_args:
+        logging_interval: step
+
+model:
+  class_path: mae.MAE_linear_probe
+  init_args:
+    ckpt_path: last.ckpt
+
+

--- a/datamodule.py
+++ b/datamodule.py
@@ -187,7 +187,7 @@ class Cifar100DataModule(_CifarDataModule):
     dataclass = CIFAR100
 
 
-class STL10DataModule(_BaseDataModule):
+class STL10PretrainDataModule(_BaseDataModule):
     num_classes = 10
     def prepare_data(self):
         pass
@@ -221,6 +221,43 @@ class STL10DataModule(_BaseDataModule):
         self.data_val = STL10(
             root = self.data_dir,
             split = 'train', 
+            transform = self.transforms(True)
+        )
+
+class STL10ReadoutDataModule(_BaseDataModule):
+    num_classes = 10
+    def prepare_data(self):
+        pass
+        #self.dataclass(self.data_dir, download=False)
+
+    def transforms(self, val=False):
+        if not val:
+            tform = transforms.Compose([
+                transforms.Resize(self.size),
+                transforms.Pad(self.size[0] // 8, padding_mode='reflect'),
+                transforms.RandomAffine((-10, 10), (0, 1/8), (1, 1.2)),
+                transforms.CenterCrop(self.size),
+                transforms.RandomHorizontalFlip(0.5),
+                transforms.ToTensor(),
+                transforms.Normalize((0.4467, 0.4398, 0.4066), (0.2603, 0.2566, 0.2713))
+            ])
+        else:
+            tform = transforms.Compose([
+                transforms.Resize(self.size),
+                transforms.ToTensor(),
+                transforms.Normalize((0.4467, 0.4398, 0.4066), (0.2603, 0.2566, 0.2713))
+            ])
+        return tform
+
+    def setup(self, stage=None):
+        self.data_train = STL10(
+            root = self.data_dir,
+            split = 'train', 
+            transform = self.transforms(not self.augment)
+        )
+        self.data_val = STL10(
+            root = self.data_dir,
+            split = 'test', 
             transform = self.transforms(True)
         )
 

--- a/lightning_readout.py
+++ b/lightning_readout.py
@@ -1,5 +1,5 @@
 import math
-from datamodule import STL10DataModule
+from datamodule import STL10ReadoutDataModule
 import os
 from typing import Any, Tuple, Union
 from mae import MAE_linear_probing, MAE
@@ -9,7 +9,7 @@ import timm
 import torch
 from torch import distributed
 import torchvision
-# os.environ['CUDA_LAUNCH_BLOCKING'] = "1"
+os.environ['CUDA_LAUNCH_BLOCKING'] = "1"
 # os.environ['TORCH_USE_CUDA_DSA'] = "1"
 # Load ViT model from ckpt
 ckpt_model = torch.load('last.ckpt')  # upload checkpoint to aws
@@ -17,7 +17,7 @@ model = MAE_linear_probing(ckpt_model)
 # model = MAE()
 
 # Prepare trainer with correct data splits
-stl10 = STL10DataModule(data_dir='../Datasets/stl10_binary', batch_size=1, num_workers=0, pin_memory=True, size=224, augment=True, num_samples=None)
+stl10 = STL10ReadoutDataModule(data_dir='/scratch-shared/matt1/data', batch_size=64, num_workers=17, pin_memory=True, size=224, augment=True, num_samples=None)
 trainer = Trainer()
 trainer.fit(model, datamodule=stl10)
 pass

--- a/lightning_readout.py
+++ b/lightning_readout.py
@@ -1,0 +1,23 @@
+import math
+from datamodule import STL10DataModule
+import os
+from typing import Any, Tuple, Union
+from mae import MAE_linear_probing, MAE
+import pytorch_lightning as pl
+from pytorch_lightning import LightningModule, Trainer
+import timm
+import torch
+from torch import distributed
+import torchvision
+# os.environ['CUDA_LAUNCH_BLOCKING'] = "1"
+# os.environ['TORCH_USE_CUDA_DSA'] = "1"
+# Load ViT model from ckpt
+ckpt_model = torch.load('last.ckpt')  # upload checkpoint to aws
+model = MAE_linear_probing(ckpt_model)
+# model = MAE()
+
+# Prepare trainer with correct data splits
+stl10 = STL10DataModule(data_dir='../Datasets/stl10_binary', batch_size=1, num_workers=0, pin_memory=True, size=224, augment=True, num_samples=None)
+trainer = Trainer()
+trainer.fit(model, datamodule=stl10)
+pass

--- a/linear_probe.py
+++ b/linear_probe.py
@@ -1,0 +1,13 @@
+from pytorch_lightning.cli import LightningCLI
+from dotenv import load_dotenv
+import torch
+from dotenv import load_dotenv
+
+if __name__ == '__main__':
+    load_dotenv('.env')
+    torch.set_float32_matmul_precision('medium')
+    cli = LightningCLI(parser_kwargs={'parser_mode': 'omegaconf'}, run=False)
+    cli.trainer.fit(cli.model, cli.datamodule)
+    cli.trainer.test(cli.model, cli.datamodule)
+
+

--- a/train.py
+++ b/train.py
@@ -1,11 +1,9 @@
 from pytorch_lightning.cli import LightningCLI
 import torch
-import os
-
+from dotenv import load_dotenv
 
 if __name__ == '__main__':
-    # load environment variables from ./.env
- 
-    os.environ["DATADIR"] = "/scratch-shared/matt1/data"
+
+    load_dotenv('.env')
     torch.set_float32_matmul_precision('medium')
     cli = LightningCLI(parser_kwargs={'parser_mode': 'omegaconf'})

--- a/train.py
+++ b/train.py
@@ -1,11 +1,11 @@
 from pytorch_lightning.cli import LightningCLI
 import torch
-
-from dotenv import load_dotenv
+import os
 
 
 if __name__ == '__main__':
     # load environment variables from ./.env
-    load_dotenv('.env')
+ 
+    os.environ["DATADIR"] = "/scratch-shared/matt1/data"
     torch.set_float32_matmul_precision('medium')
     cli = LightningCLI(parser_kwargs={'parser_mode': 'omegaconf'})


### PR DESCRIPTION
Hey, 

This is my first pull request :) 

To allow analysis of representation quality, this PR implements a linear layer on top of the final encoder layer.

Changes made:
- Additional config files for the STL-10 dataset in self-supervised pretraining and linear readout
- Addition of the respective STL10 DataModules (one for pretraining, one for readout) in dataset.py
- Addition of a new model class ('class MAE_linear_probe') in mae.py with frozen encoder weights and classification head
- Creation of a new linear_probe.py file to train and evaluate the readout
- Explanation of the procedure to reproduce the results in README.md 

![image](https://github.com/catalys1/mae-pytorch/assets/99026769/ee277edc-693e-42ce-a765-ecf7e12562c6)

Best,
Matthias

This pull request addresses the issue #1. 